### PR TITLE
Collection tables

### DIFF
--- a/collection_item.go
+++ b/collection_item.go
@@ -19,9 +19,9 @@ type CollectionItem struct {
 	// this item's membership in this particular list
 	collectionId string
 	// this item's index in the collection
-	Index int
+	Index int `json:"index"`
 	// unique description of this item
-	Description string
+	Description string `json:"description"`
 }
 
 // DatastoreType is to satisfy sql_datastore.Model interface

--- a/collection_item.go
+++ b/collection_item.go
@@ -14,7 +14,7 @@ type CollectionItem struct {
 	// need a reference to the collection Id to be set to distinguish
 	// this item's membership in this particular list
 	collectionId string
-	// this item's natural index in the colleciton
+	// this item's index in the collection
 	Index int
 	// unique description of this item
 	Description string
@@ -60,14 +60,12 @@ func (c *CollectionItem) Read(store datastore.Datastore) error {
 
 // Save a collection
 func (c *CollectionItem) Save(store datastore.Datastore) (err error) {
-	// fmt.Println("pre url save:", c.Url)
 	u := &c.Url
 	if err := u.Save(store); err != nil {
 		return err
 	}
 
 	c.Url = *u
-	// fmt.Println("post url save:", c.Url)
 	return store.Put(c.Key(), c)
 }
 
@@ -78,7 +76,11 @@ func (c *CollectionItem) Delete(store datastore.Datastore) error {
 
 func (c *CollectionItem) NewSQLModel(key datastore.Key) sql_datastore.Model {
 	l := key.List()
-	if len(l) == 2 {
+	if len(l) == 1 {
+		return &CollectionItem{
+			collectionId: datastore.NamespaceValue(l[0]),
+		}
+	} else if len(l) == 2 {
 		return &CollectionItem{
 			collectionId: datastore.NamespaceValue(l[0]),
 			Url:          Url{Id: datastore.NamespaceValue(l[1])},
@@ -113,7 +115,7 @@ func (c *CollectionItem) SQLParams(cmd sql_datastore.Cmd) []interface{} {
 	case sql_datastore.CmdSelectOne, sql_datastore.CmdExistsOne, sql_datastore.CmdDeleteOne:
 		return []interface{}{c.collectionId, c.Url.Id}
 	case sql_datastore.CmdList:
-		return nil
+		return []interface{}{c.collectionId}
 	default:
 		return []interface{}{
 			c.collectionId,

--- a/collection_item.go
+++ b/collection_item.go
@@ -1,0 +1,148 @@
+package archive
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/datatogether/sql_datastore"
+	"github.com/datatogether/sqlutil"
+	"github.com/ipfs/go-datastore"
+)
+
+type CollectionItem struct {
+	// need a reference to the collection Id to be set to distinguish
+	// this item's membership in this particular list
+	collectionId string
+	// Collection Items are Url's at heart
+	Url
+	// this item's natural index in the colleciton
+	Index int
+	// unique description of this item
+	Description string
+}
+
+func (c CollectionItem) DatastoreType() string {
+	return "CollectionItem"
+}
+
+func (c CollectionItem) GetId() string {
+	return c.Id
+}
+
+func (c CollectionItem) Key() datastore.Key {
+	return datastore.NewKey(fmt.Sprintf("%s:%s/%s", c.DatastoreType(), c.collectionId, c.GetId()))
+}
+
+// Read collection from db
+func (c *CollectionItem) Read(store datastore.Datastore) error {
+	ci, err := store.Get(c.Key())
+	if err != nil {
+		return err
+	}
+
+	got, ok := ci.(*CollectionItem)
+	if !ok {
+		return ErrInvalidResponse
+	}
+	*c = *got
+	return nil
+}
+
+// Save a collection
+func (c *CollectionItem) Save(store datastore.Datastore) (err error) {
+	// var exists bool
+
+	// if c.Id != "" {
+	// 	exists, err = store.Has(c.Key())
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// }
+
+	// if !exists {
+	// 	c.Id = uuid.New()
+	// 	c.Created = time.Now().Round(time.Second)
+	// 	c.Updated = c.Created
+	// } else {
+	// 	c.Updated = time.Now().Round(time.Second)
+	// }
+
+	return store.Put(c.Key(), c)
+}
+
+// Delete a collection, should only do for erronious additions
+func (c *CollectionItem) Delete(store datastore.Datastore) error {
+	return store.Delete(c.Key())
+}
+
+func (c *CollectionItem) NewSQLModel(key datastore.Key) sql_datastore.Model {
+	l := key.List()
+	if len(l) == 2 {
+		return &CollectionItem{
+			collectionId: l[0],
+			Url:          Url{Id: l[1]},
+		}
+	}
+	return &CollectionItem{}
+}
+
+func (c CollectionItem) SQLQuery(cmd sql_datastore.Cmd) string {
+	switch cmd {
+	case sql_datastore.CmdCreateTable:
+		return qCollectionItemCreateTable
+	case sql_datastore.CmdExistsOne:
+		return qCollectionItemExists
+	case sql_datastore.CmdSelectOne:
+		return qCollectionItemById
+	case sql_datastore.CmdInsertOne:
+		return qCollectionItemInsert
+	case sql_datastore.CmdUpdateOne:
+		return qCollectionItemUpdate
+	case sql_datastore.CmdDeleteOne:
+		return qCollectionItemDelete
+	case sql_datastore.CmdList:
+		return qCollectionItems
+	default:
+		return ""
+	}
+}
+
+func (c *CollectionItem) SQLParams(cmd sql_datastore.Cmd) []interface{} {
+	switch cmd {
+	case sql_datastore.CmdSelectOne, sql_datastore.CmdExistsOne, sql_datastore.CmdDeleteOne:
+		return []interface{}{c.collectionId, c.Url.Id}
+	case sql_datastore.CmdList:
+		return nil
+	default:
+		return []interface{}{
+			c.collectionId,
+			c.Url.Id,
+			c.Index,
+			c.Description,
+		}
+	}
+}
+
+// UnmarshalSQL reads an sql response into the collection receiver
+// it expects the request to have used collectionCols() for selection
+func (c *CollectionItem) UnmarshalSQL(row sqlutil.Scannable) (err error) {
+	var (
+		collectionId, urlId, description string
+		index                            int
+	)
+
+	if err := row.Scan(&collectionId, &urlId, &index, &description); err != nil {
+		if err == sql.ErrNoRows {
+			return ErrNotFound
+		}
+		return err
+	}
+
+	*c = CollectionItem{
+		collectionId: collectionId,
+		Url:          Url{Id: urlId},
+		Index:        index,
+		Description:  description,
+	}
+
+	return nil
+}

--- a/collection_item_test.go
+++ b/collection_item_test.go
@@ -1,0 +1,116 @@
+package archive
+
+import (
+	"fmt"
+	"github.com/datatogether/sql_datastore"
+	"github.com/ipfs/go-datastore"
+	"testing"
+)
+
+// confirm CollectionItem conforms to sql datastore mode
+var _ = sql_datastore.Model(&CollectionItem{})
+
+func TestCollectionItemStorage(t *testing.T) {
+	store := datastore.NewMapDatastore()
+
+	c := &Collection{Title: "test collection"}
+	if err := c.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	u := Url{Url: "http://example.url.test.com"}
+
+	item := &CollectionItem{collectionId: c.Id, Url: u, Index: 0, Description: "Description"}
+	if err := item.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	item2 := &CollectionItem{collectionId: c.Id, Url: u}
+	if err := item2.Read(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if err := CompareCollectionItems(item, item2); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	item.Description = "Updated Description"
+	if err := item.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	item2 = &CollectionItem{collectionId: c.Id, Url: u}
+	if err := item2.Read(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if err := CompareCollectionItems(item, item2); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if err := item.Delete(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+}
+
+func TestCollectionItemSQLStorage(t *testing.T) {
+	// defer resetTestData(appDB, "collections")
+
+	// store := sql_datastore.NewDatastore(appDB)
+	// if err := store.Register(&Collection{}); err != nil {
+	// 	t.Error(err.Error())
+	// 	return
+	// }
+
+	// c := &Collection{Title: "test collection"}
+	// if err := c.Save(store); err != nil {
+	// 	t.Error(err.Error())
+	// 	return
+	// }
+
+	// c.Creator = "penelope"
+	// if err := c.Save(store); err != nil {
+	// 	t.Error(err.Error())
+	// 	return
+	// }
+
+	// c2 := &Collection{Id: c.Id}
+	// if err := c2.Read(store); err != nil {
+	// 	t.Error(err.Error())
+	// 	return
+	// }
+
+	// if err := CompareCollections(c, c2); err != nil {
+	// 	t.Error(err.Error())
+	// 	return
+	// }
+
+	// if err := c.Delete(store); err != nil {
+	// 	t.Error(err.Error())
+	// 	return
+	// }
+}
+
+func CompareCollectionItems(a, b *CollectionItem) error {
+	if err := CompareUrls(&a.Url, &b.Url); err != nil {
+		return fmt.Errorf("url mismatch: %s", err.Error())
+	}
+	if a.collectionId != b.collectionId {
+		return fmt.Errorf("collectionId mismatch: %d != %d", a.Index, b.Index)
+	}
+	if a.Index != b.Index {
+		return fmt.Errorf("Index mismatch: %d != %d", a.Index, b.Index)
+	}
+	if a.Description != b.Description {
+		return fmt.Errorf("Description mistmatch: %s != %s", a.Description, b.Description)
+	}
+	return nil
+}

--- a/collection_items.go
+++ b/collection_items.go
@@ -1,0 +1,67 @@
+package archive
+
+import (
+	"github.com/datatogether/sql_datastore"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
+)
+
+// ItemCount gets the number of items in the list
+// TODO
+func (c *Collection) ItemCount(store datastore.Datastore) (int, error) {
+	return 0, nil
+}
+
+func (c *Collection) SaveItems(store datastore.Datastore, items []*CollectionItem) error {
+	for _, item := range items {
+		item.collectionId = c.Id
+		if err := item.Save(store); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Collection) DeleteItems(store datastore.Datastore, items []*CollectionItem) error {
+	for _, item := range items {
+		item.collectionId = c.Id
+		if err := item.Delete(store); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Collection) ReadItems(store datastore.Datastore, orderby string, limit, offset int) (items []*CollectionItem, err error) {
+	items = make([]*CollectionItem, limit)
+
+	res, err := store.Query(query.Query{
+		Limit:  limit,
+		Offset: offset,
+		Orders: []query.Order{
+			query.OrderByValue{
+				TypedOrder: sql_datastore.OrderBy(orderby),
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	i := 0
+	for r := range res.Next() {
+		if r.Error != nil {
+			return nil, err
+		}
+
+		c, ok := r.Value.(*CollectionItem)
+		if !ok {
+			return nil, ErrInvalidResponse
+		}
+
+		items[i] = c
+		i++
+	}
+
+	return items[:i], nil
+}

--- a/collection_items_test.go
+++ b/collection_items_test.go
@@ -1,0 +1,75 @@
+package archive
+
+import (
+	"github.com/datatogether/sql_datastore"
+	"testing"
+)
+
+func TestCollectionItemsSQLStorage(t *testing.T) {
+	defer resetTestData(appDB, "collection_items", "collections", "urls")
+
+	store := sql_datastore.NewDatastore(appDB)
+	if err := store.Register(&Collection{}, &CollectionItem{}, &Url{}); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	c := &Collection{Title: "test collection Item Count"}
+	if err := c.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	count, err := c.ItemCount(store)
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if count != 0 {
+		t.Errorf("count mistmatch. expected %d, got %d", 0, count)
+		return
+	}
+
+	saveitems := []*CollectionItem{
+		&CollectionItem{Url: Url{Url: "http://test.0.com"}, Index: 0, Description: "zero"},
+		&CollectionItem{Url: Url{Url: "http://test.1.com"}, Index: 1, Description: "one"},
+		&CollectionItem{Url: Url{Url: "http://test.2.com"}, Index: 2, Description: "two"},
+	}
+
+	if err := c.SaveItems(store, saveitems); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if count, err := c.ItemCount(store); err != nil {
+		t.Error(err.Error())
+		return
+	} else if count != len(saveitems) {
+		t.Errorf("count mistmatch. expected %d, got %d", len(saveitems), count)
+		return
+	}
+
+	readitems, err := c.ReadItems(store, "created DESC", 100, 0)
+	if err != nil {
+		t.Error(err.Error())
+		return
+	} else if len(readitems) != len(saveitems) {
+		t.Errorf("count mistmatch. expected %d, got %d", len(saveitems), count)
+		return
+	}
+
+	if err := c.DeleteItems(store, saveitems); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if count, err := c.ItemCount(store); err != nil {
+		t.Error(err.Error())
+		return
+	} else if count != 0 {
+		t.Errorf("count mistmatch. expected %d, got %d", 0, count)
+		return
+	}
+
+}

--- a/collections_test.go
+++ b/collections_test.go
@@ -16,7 +16,7 @@ func TestListCollections(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	if len(collections) != 1 {
+	if len(collections) != 4 {
 		t.Errorf("collections length mismatch")
 	}
 
@@ -24,7 +24,7 @@ func TestListCollections(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	if len(collections) != 0 {
+	if len(collections) != 3 {
 		t.Errorf("collections length mismatch")
 	}
 }
@@ -36,11 +36,11 @@ func TestCollectionsByCreator(t *testing.T) {
 		return
 	}
 
-	collections, err := CollectionsByCreator(store, "test_user_key", "created DESC", 20, 0)
+	collections, err := CollectionsByCreator(store, "EDGI_644b51b9567d0d999e40f697d7406a26030cde95a83775d285ff1f57a73b3ebc", "created DESC", 20, 0)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	if len(collections) != 1 {
-		t.Errorf("collections length mismatch")
+	if len(collections) != 2 {
+		t.Errorf("collections length mismatch: %d != %d", len(collections), 2)
 	}
 }

--- a/datarepo.go
+++ b/datarepo.go
@@ -80,9 +80,9 @@ func (d *DataRepo) Delete(store datastore.Datastore) error {
 	return store.Delete(d.Key())
 }
 
-func (d *DataRepo) NewSQLModel(id string) sql_datastore.Model {
+func (d *DataRepo) NewSQLModel(key datastore.Key) sql_datastore.Model {
 	return &DataRepo{
-		Id: id,
+		Id: key.Name(),
 	}
 }
 

--- a/link.go
+++ b/link.go
@@ -109,9 +109,9 @@ func (l *Link) calcHash() {
 	l.Hash = hex.EncodeToString(mhBuf)
 }
 
-func (l *Link) NewSQLModel(id string) sql_datastore.Model {
+func (l *Link) NewSQLModel(key datastore.Key) sql_datastore.Model {
 	return &Link{
-		Hash: id,
+		Hash: key.Name(),
 		Src:  l.Src,
 		Dst:  l.Dst,
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -44,6 +44,7 @@ func setupTestDatabase() func() {
 		"metadata",
 		"snapshots",
 		"collections",
+		"collection_items",
 		"archive_requests",
 		"uncrawlables",
 		"data_repos"); err != nil {
@@ -70,6 +71,7 @@ func initializeAppSchema(db *sql.DB) (func(), error) {
 		"create-metadata",
 		"create-snapshots",
 		"create-collections",
+		"create-collection_items",
 		"create-archive_requests",
 		"create-uncrawlables",
 		"create-data_repos",

--- a/metadata.go
+++ b/metadata.go
@@ -208,7 +208,7 @@ func (m *Metadata) Write(db *sql.DB) error {
 
 			// TODO - this is a straight set, should be derived from consensus calculation
 			u.Title = str
-			if err := u.Update(store); err != nil {
+			if err := u.Save(store); err != nil {
 				return
 			}
 		}()

--- a/primer.go
+++ b/primer.go
@@ -181,8 +181,8 @@ func (p *Primer) Delete(store datastore.Datastore) error {
 	return store.Delete(p.Key())
 }
 
-func (p *Primer) NewSQLModel(id string) sql_datastore.Model {
-	return &Primer{Id: id}
+func (p *Primer) NewSQLModel(key datastore.Key) sql_datastore.Model {
+	return &Primer{Id: key.Name()}
 }
 
 func (p *Primer) SQLQuery(cmd sql_datastore.Cmd) string {

--- a/queries.go
+++ b/queries.go
@@ -8,16 +8,14 @@ CREATE TABLE IF NOT EXISTS collections (
   updated          timestamp NOT NULL,
   creator          text NOT NULL DEFAULT '',
   title            text NOT NULL DEFAULT '',
-  url              text NOT NULL DEFAULT '',
-  schema           json,
-  contents         json
+  url              text NOT NULL DEFAULT ''
 );`
 
 // list collections by reverse cronological date created
 // paginated
 const qCollections = `
 SELECT
-  id, created, updated, creator, title, description, url, schema, contents
+  id, created, updated, creator, title, description, url
 FROM collections 
 ORDER BY created DESC 
 LIMIT $1 OFFSET $2;`
@@ -25,7 +23,7 @@ LIMIT $1 OFFSET $2;`
 // list collections by creator
 const qCollectionsByCreator = `
 SELECT 
-  id, created, updated, creator, title, description, url, schema, contents 
+  id, created, updated, creator, title, description, url 
 FROM collections
 WHERE creator = $4
 ORDER BY $3
@@ -33,25 +31,25 @@ LIMIT $1 OFFSET $2;`
 
 // check for existence of a collection
 const qCollectionExists = `
-  SELECT exists(SELECT 1 FROM collections WHERE id = $1)
+SELECT exists(SELECT 1 FROM collections WHERE id = $1)
 `
 
 // insert a collection
 const qCollectionInsert = `
 INSERT INTO collections 
-  (id, created, updated, creator, title, description, url, schema, contents ) 
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);`
+  (id, created, updated, creator, title, description, url ) 
+VALUES ($1, $2, $3, $4, $5, $6, $7);`
 
 // update an existing collection, selecting by ID
 const qCollectionUpdate = `
 UPDATE collections 
-SET created=$2, updated=$3, creator=$4, title=$5, description=$6, url=$7, schema=$8, contents=$9
+SET created=$2, updated=$3, creator=$4, title=$5, description=$6, url=$7
 WHERE id = $1;`
 
 // read collection info by ID
 const qCollectionById = `
 SELECT 
-  id, created, updated, creator, title, description, url, schema, contents 
+  id, created, updated, creator, title, description, url 
 FROM collections 
 WHERE id = $1;`
 
@@ -59,6 +57,51 @@ WHERE id = $1;`
 const qCollectionDelete = `
 DELETE from collections 
 WHERE id = $1;`
+
+const qCollectionItemCreateTable = `
+CREATE TABLE IF NOT EXISTS collection_items (
+  collection_id    UUID NOT NULL,
+  url_id           text NOT NULL default '',
+  index            integer NOT NULL default -1,
+  description      text NOT NULL default '',
+  PRIMARY KEY      (collection_id, url_id)
+);`
+
+const qCollectionItemInsert = `
+INSERT INTO collection_items
+  (collection_id, url_id, index, description)
+VALUES
+  ($1, $2, $3, $4);`
+
+const qCollectionItemUpdate = `
+UPDATE collection_items
+SET index = $3, description = $4
+WHERE collection_id = $1 and id = $2;`
+
+const qCollectionItemDelete = `
+DELETE collection_items 
+WHERE collection_id = $1 and id = $2;`
+
+const qCollectionItemExists = `
+SELECT exists(SELECT 1 FROM collection_items where id = $2);`
+
+const qCollectionItemById = `
+SELECT
+  ci.collection_id, u.id, u.url, u.title, ci.index, ci.description
+FROM collection_items as ci, urls as u
+WHERE collection_id = $1 AND url_id = $2;`
+
+const qCollectionLength = `
+SELECT count(1) FROM collection_items WHERE collection_id = $1 and url_id = $2;`
+
+const qCollectionItems = `
+SELECT
+  ci.collection_id, u.id, u.url, u.title, ci.index, ci.description
+FROM collection_items as ci, urls as u
+WHERE collection_id = $4
+AND u.id = ci.url_id
+ORDER BY $3
+LIMIT $1 OFFSET $2;`
 
 // insert a dataRepo
 const qDataRepoInsert = `

--- a/queries.go
+++ b/queries.go
@@ -76,20 +76,20 @@ VALUES
 const qCollectionItemUpdate = `
 UPDATE collection_items
 SET index = $3, description = $4
-WHERE collection_id = $1 and id = $2;`
+WHERE collection_id = $1 and url_id = $2;`
 
 const qCollectionItemDelete = `
-DELETE collection_items 
-WHERE collection_id = $1 and id = $2;`
+DELETE FROM collection_items 
+WHERE collection_id = $1 AND url_id = $2;`
 
 const qCollectionItemExists = `
-SELECT exists(SELECT 1 FROM collection_items where id = $2);`
+SELECT exists(SELECT 1 FROM collection_items where collection_id = $1 AND url_id = $2);`
 
 const qCollectionItemById = `
 SELECT
-  ci.collection_id, u.id, u.url, u.title, ci.index, ci.description
+  ci.collection_id, u.id, u.hash, u.url, u.title, ci.index, ci.description
 FROM collection_items as ci, urls as u
-WHERE collection_id = $1 AND url_id = $2;`
+WHERE collection_id = $1 AND url_id = $2 AND u.id = ci.url_id;`
 
 const qCollectionLength = `
 SELECT count(1) FROM collection_items WHERE collection_id = $1 and url_id = $2;`
@@ -778,14 +778,14 @@ set
 where id = $1;`
 
 const qUncrawlableByUrl = `
-select 
+SELECT 
   id, url,created,updated,creator_key_id,
   name,email,event_name,agency_name,
   agency_id,subagency_id,org_id,suborg_id,subprimer_id,
   ftp,database,interactive,many_files,
   comments
-from uncrawlables 
-where url = $1;`
+FROM uncrawlables 
+WHERE url = $1;`
 
 const qUncrawlableById = `
 select 

--- a/queries.go
+++ b/queries.go
@@ -92,11 +92,11 @@ FROM collection_items as ci, urls as u
 WHERE collection_id = $1 AND url_id = $2 AND u.id = ci.url_id;`
 
 const qCollectionLength = `
-SELECT count(1) FROM collection_items WHERE collection_id = $1 and url_id = $2;`
+SELECT count(1) FROM collection_items WHERE collection_id = $1;`
 
 const qCollectionItems = `
 SELECT
-  ci.collection_id, u.id, u.url, u.title, ci.index, ci.description
+  ci.collection_id, u.id, u.hash, u.url, u.title, ci.index, ci.description
 FROM collection_items as ci, urls as u
 WHERE collection_id = $4
 AND u.id = ci.url_id

--- a/source.go
+++ b/source.go
@@ -135,7 +135,7 @@ func (c *Source) AsUrl(db *sql.DB) (*Url, error) {
 	u := &Url{Url: addr.String()}
 	if err := u.Read(store); err != nil {
 		if err == ErrNotFound {
-			if err := u.Insert(store); err != nil {
+			if err := u.Save(store); err != nil {
 				return u, err
 			}
 		} else {

--- a/source.go
+++ b/source.go
@@ -243,9 +243,9 @@ func (s *Source) Delete(store datastore.Datastore) error {
 	return store.Delete(s.Key())
 }
 
-func (s *Source) NewSQLModel(id string) sql_datastore.Model {
+func (s *Source) NewSQLModel(key datastore.Key) sql_datastore.Model {
 	return &Source{
-		Id:  id,
+		Id:  key.Name(),
 		Url: s.Url,
 	}
 }

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,5 +1,5 @@
 -- name: drop-all
-DROP TABLE IF EXISTS urls, links, primers, sources, subprimers, alerts, context, metadata, supress_alerts, snapshots, collections, archive_requests, uncrawlables, data_repos;
+DROP TABLE IF EXISTS urls, links, primers, sources, subprimers, alerts, context, metadata, supress_alerts, snapshots, collections, collection_items, archive_requests, uncrawlables, data_repos;
 
 -- name: create-primers
 CREATE TABLE IF NOT EXISTS primers (

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -96,11 +96,13 @@ CREATE TABLE IF NOT EXISTS collections (
   contents         json
 );
 
--- name: create-collection_contents
-CREATE TABLE IF NOT EXISTS collection_contents (
-	collection_id    UUID NOT NULL,
-	hash             text NOT NULL default '',
-	PRIMARY KEY      (collection_id, hash)
+-- name: create-collection_items
+CREATE TABLE IF NOT EXISTS collection_items (
+  collection_id    UUID NOT NULL,
+  url_id           text NOT NULL default '',
+  index            integer NOT NULL default -1,
+  description      text NOT NULL default '',
+  PRIMARY KEY      (collection_id, url_id)
 );
 
 -- name: create-uncrawlables

--- a/sql/test_data.sql
+++ b/sql/test_data.sql
@@ -27,9 +27,15 @@ delete from sources;
 insert into urls
   (url,created,updated,last_head,last_get,status,content_type,content_sniff,content_length,file_name,title,id,headers_took,download_took,headers,meta,hash)
 values
-	('http://www.epa.gov', '2017-01-01 00:00:01', '2017-01-01 00:00:01', '2017-01-01 00:00:01', null, 200, 'text/html; charset=utf-8', 'text/html;', -1, '', 'United States Environmental Protection Agency, US EPA', 'cee7bbd4-2bf9-4b83-b2c8-be6aeb70e771',0,0, '["X-Content-Type-Options","nosniff","Expires","Fri, 24 Feb 2017 21:53:45 GMT","Date","Fri, 24 Feb 2017 21:53:45 GMT","Etag","W/\"7f53-549471782bb42\"","X-Ua-Compatible","IE=Edge,chrome=1","X-Cached-By","Boost","Content-Type","text/html; charset=utf-8","Vary","Accept-Encoding","Accept-Ranges","bytes","Cache-Control","no-cache, no-store, must-revalidate, post-check=0, pre-check=0","Server","Apache","Connection","keep-alive","Strict-Transport-Security","max-age=31536000; preload;"]', null, '1220459219b10032cc86dcdbc0f83aea15a9d3e1119e7b5170beaee233008ea2c2de'),
+  ('http://www.epa.gov', '2017-01-01 00:00:01', '2017-01-01 00:00:01', '2017-01-01 00:00:01', null, 200, 'text/html; charset=utf-8', 'text/html;', -1, '', 'United States Environmental Protection Agency, US EPA', 'cee7bbd4-2bf9-4b83-b2c8-be6aeb70e771',0,0, '["X-Content-Type-Options","nosniff","Expires","Fri, 24 Feb 2017 21:53:45 GMT","Date","Fri, 24 Feb 2017 21:53:45 GMT","Etag","W/\"7f53-549471782bb42\"","X-Ua-Compatible","IE=Edge,chrome=1","X-Cached-By","Boost","Content-Type","text/html; charset=utf-8","Vary","Accept-Encoding","Accept-Ranges","bytes","Cache-Control","no-cache, no-store, must-revalidate, post-check=0, pre-check=0","Server","Apache","Connection","keep-alive","Strict-Transport-Security","max-age=31536000; preload;"]', null, '1220459219b10032cc86dcdbc0f83aea15a9d3e1119e7b5170beaee233008ea2c2de'),
   ('https://www.census.gov/nometa.pdf','2017-03-15 17:36:40', '2017-03-21 22:25:21','2017-03-21 22:25:20.88', '2017-03-21 22:25:20.88', 200,'text/html','application/pdf; charset=utf-8' ,164010, 'nometa.pdf','North American Industry Classification System (NAICS) Main Page � U.S. Census Bureau','4c5fc7b8-1397-4d34-980b-1d01247f9ee4',0,0 ,'["Date","Tue, 21 Mar 2017 22:25:20 GMT","Accept-Ranges","bytes","Content-Type","text/html","Strict-Transport-Security","max-age=31536000","Vary","Accept-Encoding"]',null,'1220af06510193276b5fd9ad2fc55dcc004ada557d9259ca3505478bfef0b12ed988'),
-  ('https://www.census.gov/topics/economy/classification-codes.html','2017-03-15 17:36:40', '2017-03-21 22:25:21','2017-03-21 22:25:20.88','2017-03-21 22:25:20.88384',200,'text/html','text/plain; charset=utf-8' ,164010, '','North American Industry Classification System (NAICS) Main Page � U.S. Census Bureau','4c5fc7b8-1397-4d34-980b-1d01247f9ee4',0,0 ,'["Date","Tue, 21 Mar 2017 22:25:20 GMT","Accept-Ranges","bytes","Content-Type","text/html","Strict-Transport-Security","max-age=31536000","Vary","Accept-Encoding"]',null,'12207b06510193276b5fd9ad2fc55dcc004ada557d9259ca3505478bfef0b16ed977');
+  ('https://www.census.gov/topics/economy/classification-codes.html','2017-03-15 17:36:40', '2017-03-21 22:25:21','2017-03-21 22:25:20.88','2017-03-21 22:25:20.88384',200,'text/html','text/plain; charset=utf-8' ,164010, '','North American Industry Classification System (NAICS) Main Page � U.S. Census Bureau','4c5fc7b8-1397-4d34-980b-1d01247f9ee4',0,0 ,'["Date","Tue, 21 Mar 2017 22:25:20 GMT","Accept-Ranges","bytes","Content-Type","text/html","Strict-Transport-Security","max-age=31536000","Vary","Accept-Encoding"]',null,'12207b06510193276b5fd9ad2fc55dcc004ada557d9259ca3505478bfef0b16ed977'),
+  ('https://i.imgur.com/LJf4LzX.jpg', '2017-03-15 17:36:40', '2017-03-21 22:25:21','2017-03-21 22:25:20.88','2017-03-21 22:25:20.88384', 200,'image/jpeg', 'image/jpeg', 0, '','Puppies!','fe6d9fbd-32fe-4cf3-b48f-8f5010207f4c',0,0, '["Date","Tue, 21 Mar 2017 22:25:20 GMT"]',null,''),
+  ('https://i.imgur.com/UE4nxKJ.gifv', '2017-03-15 17:36:40', '2017-03-21 22:25:21','2017-03-21 22:25:20.88','2017-03-21 22:25:20.88384', 200,'video/mp4', 'video/mp4', 0, '','Puppies!','e1a4eaff-1faf-48ea-9c2c-31968abc82bc',0,0, '["Date","Tue, 21 Mar 2017 22:25:20 GMT"]',null,''),
+  ('https://i.imgur.com/ku6IEJf.gifv', '2017-03-15 17:36:40', '2017-03-21 22:25:21','2017-03-21 22:25:20.88','2017-03-21 22:25:20.88384', 200,'video/mp4', 'video/mp4', 0, '','Puppies!','8596e6b9-9bf6-45d6-b0c2-06a0f71de2df',0,0, '["Date","Tue, 21 Mar 2017 22:25:20 GMT"]',null,''),
+  ('https://i.imgur.com/y22NjCp.jpg', '2017-03-15 17:36:40', '2017-03-21 22:25:21','2017-03-21 22:25:20.88','2017-03-21 22:25:20.88384', 200,'image/jpeg', 'image/jpeg', 0, '','Puppies!','98179ab7-8cd9-4d05-a6c8-24df846b8dd2',0,0, '["Date","Tue, 21 Mar 2017 22:25:20 GMT"]',null,''),
+  ('https://i.imgur.com/1x8lR0p.jpg', '2017-03-15 17:36:40', '2017-03-21 22:25:21','2017-03-21 22:25:20.88','2017-03-21 22:25:20.88384', 200,'image/jpeg', 'image/jpeg', 0, '','Puppies!','41471973-9595-470f-b299-30a3423e267e',0,0, '["Date","Tue, 21 Mar 2017 22:25:20 GMT"]',null,''),
+  ('http://i.imgur.com/26fVJAE.gifv', '2017-03-15 17:36:40', '2017-03-21 22:25:21','2017-03-21 22:25:20.88','2017-03-21 22:25:20.88384', 200,'video/mp4', 'video/mp4', 0, '','Puppies!','53d4c4bd-9802-41ad-82ae-1e82734d56fc',0,0, '["Date","Tue, 21 Mar 2017 22:25:20 GMT"]',null,'');
 -- name: delete-urls
 delete from urls;
 
@@ -41,7 +47,7 @@ delete from links;
 
 -- name: insert-snapshots
 -- insert into snapshots values
--- 	();
+--  ();
 -- name: delete-snapshots
 delete from snapshots;
 
@@ -54,17 +60,35 @@ delete from metadata;
 
 -- name: insert-collections
 insert into collections 
-  (id, created, updated, creator, title, description, url, schema, contents)
+  (id, created, updated, 
+    creator,
+    title, description, url)
 values
-  ('76dd07ac-54cb-4f9d-b0a6-88d3d55c0d9d', '2017-01-01 00:00:01', '2017-01-01 00:00:01', 'test_user_key', 'Test Collection', 'a collection of urls', '', null, null);
+  ('6995febc-b7be-49ba-8297-1db68a703c3c','2017-07-13 15:57:32','2017-07-13 21:39:38',
+    'EDGI_644b51b9567d0d999e40f697d7406a26030cde95a83775d285ff1f57a73b3ebc',
+    'EPA TRU Datasets', 'essential TRU datasets', ''),
+  ('f444f782-2110-43ca-956c-2c5f0dd56b1a','2017-07-12 23:18:59','2017-07-13 21:57:11',
+    'EDGI_644b51b9567d0d999e40f697d7406a26030cde95a83775d285ff1f57a73b3ebc',
+    'NOAA Volatile Organic Compound CSV files', 'VOC datasests', ''),
+  ('a73a9d04-0fdb-40c8-a97f-288af36e8f6f','2017-07-13 18:45:03','2017-07-13 21:59:25',
+    'blackglade_644b51b9567d0d999e40f697d7406a26030cde95a83775d285ff1f57a73b3ebc',
+    'Test Collection', '', ''),
+  ('4ed29ffe-150f-42ce-b0a9-2aadde646bcb','2017-07-11 17:50:19','2017-07-14 00:30:10',
+    'jeffliu_644b51b9567d0d999e40f697d7406a26030cde95a83775d285ff1f57a73b3ebc',
+    'All of the puppies', 'My fav puppy images', '');
 -- name: delete-collections
 delete from collections;
 
 -- name: insert-collection_items
-INSERT into collection_items
+INSERT INTO collection_items
   (collection_id, url_id, index, description)
 VALUES
-  ('76dd07ac-54cb-4f9d-b0a6-88d3d55c0d9d', 'cee7bbd4-2bf9-4b83-b2c8-be6aeb70e771', 0, 'epa url in the collection');
+  ('4ed29ffe-150f-42ce-b0a9-2aadde646bcb', 'fe6d9fbd-32fe-4cf3-b48f-8f5010207f4c', 0, 'puppies in a car'),
+  ('4ed29ffe-150f-42ce-b0a9-2aadde646bcb', 'e1a4eaff-1faf-48ea-9c2c-31968abc82bc', 1, 'puppy in a sweater in a car'),
+  ('4ed29ffe-150f-42ce-b0a9-2aadde646bcb', '8596e6b9-9bf6-45d6-b0c2-06a0f71de2df', 2, 'momma with puppies'),
+  ('4ed29ffe-150f-42ce-b0a9-2aadde646bcb', '98179ab7-8cd9-4d05-a6c8-24df846b8dd2', 3, 'brown puppy'),
+  ('4ed29ffe-150f-42ce-b0a9-2aadde646bcb', '41471973-9595-470f-b299-30a3423e267e', 4, ''),
+  ('4ed29ffe-150f-42ce-b0a9-2aadde646bcb', '53d4c4bd-9802-41ad-82ae-1e82734d56fc', 5, '');
 -- name: delete-collection_items
 DELETE FROM collection_items;
 

--- a/sql/test_data.sql
+++ b/sql/test_data.sql
@@ -60,6 +60,14 @@ values
 -- name: delete-collections
 delete from collections;
 
+-- name: insert-collection_items
+INSERT into collection_items
+  (collection_id, url_id, index, description)
+VALUES
+  ('76dd07ac-54cb-4f9d-b0a6-88d3d55c0d9d', 'cee7bbd4-2bf9-4b83-b2c8-be6aeb70e771', 0, 'epa url in the collection');
+-- name: delete-collection_items
+DELETE FROM collection_items;
+
 -- name: insert-uncrawlables
 insert into uncrawlables 
   ( id,url,created,updated,creator_key_id,

--- a/uncrawlable.go
+++ b/uncrawlable.go
@@ -124,9 +124,9 @@ func (u *Uncrawlable) Delete(store datastore.Datastore) error {
 	return store.Delete(u.Key())
 }
 
-func (u *Uncrawlable) NewSQLModel(id string) sql_datastore.Model {
+func (u *Uncrawlable) NewSQLModel(key datastore.Key) sql_datastore.Model {
 	return &Uncrawlable{
-		Id:  id,
+		Id:  key.Name(),
 		Url: u.Url,
 	}
 }

--- a/url.go
+++ b/url.go
@@ -39,6 +39,7 @@ var notContentExtensions = map[string]bool{
 }
 
 // URL represents... a url.
+// TODO - consider renaming to Resource
 type Url struct {
 	// version 4 uuid
 	// urls can/should/must also be be uniquely identified by Url
@@ -497,9 +498,9 @@ func (u *Url) HeadersMap() (headers map[string]string) {
 	return
 }
 
-func (u *Url) NewSQLModel(id string) sql_datastore.Model {
+func (u *Url) NewSQLModel(key datastore.Key) sql_datastore.Model {
 	return &Url{
-		Id:   id,
+		Id:   key.Name(),
 		Url:  u.Url,
 		Hash: u.Hash,
 	}

--- a/url_test.go
+++ b/url_test.go
@@ -12,13 +12,13 @@ func TestUrlStorage(t *testing.T) {
 	store := datastore.NewMapDatastore()
 
 	u := &Url{Url: "http://youtube.com"}
-	if err := u.Insert(store); err != nil {
+	if err := u.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	u.ContentLength = 10
-	if err := u.Update(store); err != nil {
+	if err := u.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -53,13 +53,13 @@ func TestUrlSQLStorage(t *testing.T) {
 	}
 
 	u := &Url{Url: "http://youtube.com"}
-	if err := u.Insert(store); err != nil {
+	if err := u.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	u.ContentLength = 10
-	if err := u.Update(store); err != nil {
+	if err := u.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}

--- a/url_test.go
+++ b/url_test.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"fmt"
 	// "fmt"
 	"github.com/datatogether/sql_datastore"
 	"github.com/ipfs/go-datastore"
@@ -161,4 +162,77 @@ func TestUrlSuspectedContentUrl(t *testing.T) {
 			t.Errorf("case %d fail: %t != %t", i, c.expect, got)
 		}
 	}
+}
+
+func CompareUrls(a, b *Url) error {
+	if a == nil && b != nil || a != nil && b == nil {
+		return fmt.Errorf("nil mismatch %s != %s", a, b)
+	} else if a == nil && b == nil {
+		return nil
+	}
+
+	if a.Id != b.Id {
+		return fmt.Errorf("id mismatch: %s != %s", a.Id, b.Id)
+	}
+
+	if !a.Created.Equal(b.Created) {
+		return fmt.Errorf("created mismatch: %s != %s", a.Created, b.Created)
+	}
+
+	if !a.Updated.Equal(b.Updated) {
+		return fmt.Errorf("updated mismatch: %s != %s", a.Updated, b.Updated)
+	}
+
+	if a.Url != b.Url {
+		return fmt.Errorf("url mismatch: %s != %s ", a.Url, b.Url)
+	}
+	if a.Hash != b.Hash {
+		return fmt.Errorf("Hash mistmatch: %s != %s", a.Hash, b.Hash)
+	}
+
+	if a.LastGet != b.LastGet {
+		return fmt.Errorf("LastGet mistmatch: %s != %s", a.LastGet, b.LastGet)
+	}
+	if a.LastHead != b.LastHead {
+		return fmt.Errorf("LastHead mistmatch: %s != %s", a.LastHead, b.LastHead)
+	}
+	if a.Status != b.Status {
+		return fmt.Errorf("Status mistmatch: %s != %s", a.Status, b.Status)
+	}
+	if a.ContentType != b.ContentType {
+		return fmt.Errorf("ContentType mistmatch: %s != %s", a.ContentType, b.ContentType)
+	}
+	if a.ContentSniff != b.ContentSniff {
+		return fmt.Errorf("ContentSniff mistmatch: %s != %s", a.ContentSniff, b.ContentSniff)
+	}
+	if a.ContentLength != b.ContentLength {
+		return fmt.Errorf("ContentLength mistmatch: %s != %s", a.ContentLength, b.ContentLength)
+	}
+	if a.FileName != b.FileName {
+		return fmt.Errorf("FileName mistmatch: %s != %s", a.FileName, b.FileName)
+	}
+	if a.Title != b.Title {
+		return fmt.Errorf("Title mistmatch: %s != %s", a.Title, b.Title)
+	}
+	if a.DownloadTook != b.DownloadTook {
+		return fmt.Errorf("DownloadTook mistmatch: %s != %s", a.DownloadTook, b.DownloadTook)
+	}
+	if a.HeadersTook != b.HeadersTook {
+		return fmt.Errorf("HeadersTook mistmatch: %s != %s", a.HeadersTook, b.HeadersTook)
+	}
+	// TODO - proper comparison
+	// if a.Headers != b.Headers {
+	// 	return fmt.Errorf("Headers mistmatch: %s != %s", a.Headers, b.Headers)
+	// }
+	// if a.Meta != b.Meta {
+	// 	return fmt.Errorf("Meta mistmatch: %s != %s", a.Meta, b.Meta)
+	// }
+	if a.ContentUrl != b.ContentUrl {
+		return fmt.Errorf("ContentUrl mistmatch: %s != %s", a.ContentUrl, b.ContentUrl)
+	}
+	if a.Uncrawlable != b.Uncrawlable {
+		return fmt.Errorf("Uncrawlable mistmatch: %s != %s", a.Uncrawlable, b.Uncrawlable)
+	}
+
+	return nil
 }

--- a/urls_test.go
+++ b/urls_test.go
@@ -19,7 +19,7 @@ func TestListUrls(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	if len(urls) != 3 {
+	if len(urls) != 9 {
 		t.Errorf("urls length mismatch")
 	}
 


### PR DESCRIPTION
This PR allows collections to scale, and makes collections do cooler stuff. It relies on datatogether/sql_datastore#2 to do that cooler stuff.

In the interest of getting the Collections feature out the door, I hacked in a very-terrible implementation of collections where they were stored as JSON on the collections table. This is bad. Won't scale. Will be slow. Badbadnotgood.

So here we refactor away the bad bits, replacing them with paginated collection items, allowing collections to scale up to 10s / 100s of thousands of entries if needed.

Cool. "Scale". Whatever. The more interesting part is that collection items are now composed of entries of Urls, which we can do more interesting things with. For example, if I add a url to my collection, and you add the same url to your collection, they're now formally linked. If Sentry crawls that link and updates the status of that URL, it updates for both of our collections. I can make notes about that url in my collection, and you can do the same in yours, and those notes won't get crossed, but we can create views that show both of our notes on that urls. If I add metadata about that Url, your collection can see it. If that url is in a primer, we can surface that too.

Things are (hopefully) about to get fuego once we surface this stuff in the frontend.