### PR TITLE
update warc method calls and replace memfs with cafs

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -42,7 +42,7 @@ func extractResourceRecords(resr *warc.Record, records warc.Records) (warc.Recor
 		return nil, err
 	}
 
-	reqUrl, err := url.Parse(resr.TargetUri())
+	reqUrl, err := url.Parse(resr.TargetURI())
 	if err != nil {
 		return nil, err
 	}
@@ -54,8 +54,8 @@ func extractResourceRecords(resr *warc.Record, records warc.Records) (warc.Recor
 		}
 
 		// skip if we've already archived this url
-		if records.TargetUriRecord(abs.String(), warc.RecordTypeResponse, warc.RecordTypeResource) != nil ||
-			rrecs.TargetUriRecord(abs.String(), warc.RecordTypeResponse, warc.RecordTypeResource) != nil {
+		if records.TargetURIRecord(abs.String(), warc.RecordTypeResponse, warc.RecordTypeResource) != nil ||
+			rrecs.TargetURIRecord(abs.String(), warc.RecordTypeResponse, warc.RecordTypeResource) != nil {
 			continue
 		}
 

--- a/http.go
+++ b/http.go
@@ -14,7 +14,7 @@ import (
 // the given records pointer, returning the response record & a list of all dependant resources
 func DoRequest(req *http.Request, records warc.Records) (reqr, resr *warc.Record, err error) {
 	// don't perform requests for urls already in this list of archives
-	if rec := records.TargetUriRecord(req.URL.String(), warc.RecordTypeResponse, warc.RecordTypeResource); rec != nil {
+	if rec := records.TargetURIRecord(req.URL.String(), warc.RecordTypeResponse, warc.RecordTypeResource); rec != nil {
 		return
 	}
 
@@ -39,7 +39,7 @@ func RequestRecord(req *http.Request) *warc.Record {
 		Type: warc.RecordTypeRequest,
 		Headers: map[string]string{
 			warc.FieldNameContentType:   "application/http; msgtype=request",
-			warc.FieldNameWARCRecordID:  warc.NewUuid(),
+			warc.FieldNameWARCRecordID:  warc.NewUUID(),
 			warc.FieldNameWARCTargetURI: req.URL.String(),
 		},
 		Content: bytes.NewBuffer(body),
@@ -49,7 +49,7 @@ func RequestRecord(req *http.Request) *warc.Record {
 func contentFromHttpRequest(req *http.Request) []byte {
 	buf := &bytes.Buffer{}
 
-	if err := warc.WriteRequestStatusAndHeaders(buf, req); err != nil {
+	if err := warc.WriteRequestMethodAndHeaders(buf, req); err != nil {
 		return buf.Bytes()
 	}
 
@@ -73,7 +73,7 @@ func HttpResponseRecord(res *http.Response) (*warc.Record, error) {
 	}
 
 	buf := &bytes.Buffer{}
-	warc.WriteHttpHeaders(buf, res.Header)
+	warc.WriteHTTPHeaders(buf, res.Header)
 	buf.WriteString("\r\n")
 	buf.Write(sanitized)
 
@@ -82,7 +82,7 @@ func HttpResponseRecord(res *http.Response) (*warc.Record, error) {
 		Headers: map[string]string{
 			warc.FieldNameWARCPayloadDigest:         warc.Sha1Digest(raw),
 			warc.FieldNameContentType:               "application/http; msgtype=response",
-			warc.FieldNameWARCRecordID:              warc.NewUuid(),
+			warc.FieldNameWARCRecordID:              warc.NewUUID(),
 			warc.FieldNameWARCIdentifiedPayloadType: mimetype,
 			warc.FieldNameWARCTargetURI:             res.Request.URL.String(),
 		},

--- a/package.go
+++ b/package.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/datatogether/warc"
-	"github.com/qri-io/cafs/memfs"
+	"github.com/qri-io/cafs"
 )
 
 func PackagePathName(rawurl string) string {
@@ -27,8 +27,8 @@ func PackagePathName(rawurl string) string {
 	return strings.TrimPrefix(u.String(), "/")
 }
 
-func PackageRecords(urls []string, records warc.Records) (*memfs.Memdir, error) {
-	pkg := memfs.NewMemdir("/")
+func PackageRecords(urls []string, records warc.Records) (*cafs.Memdir, error) {
+	pkg := cafs.NewMemdir("/")
 	// cheap hack for now to only add files once, this should happen *much* earlier
 	// in the archival process
 	added := map[string]bool{}
@@ -40,8 +40,8 @@ func PackageRecords(urls []string, records warc.Records) (*memfs.Memdir, error) 
 			continue
 		}
 
-		// path := rw.Urlrw.RewriteString(rec.TargetUri())
-		path := PackagePathName(rec.TargetUri())
+		// path := rw.Urlrw.RewriteString(rec.TargetURI())
+		path := PackagePathName(rec.TargetURI())
 		if added[path] {
 			continue
 		}
@@ -49,7 +49,7 @@ func PackageRecords(urls []string, records warc.Records) (*memfs.Memdir, error) 
 
 		added[path] = true
 		fmt.Println(path)
-		pkg.AddChildren(memfs.NewMemfileBytes(path, body))
+		pkg.AddChildren(cafs.NewMemfileBytes(path, body))
 	}
 
 	buf := &bytes.Buffer{}
@@ -78,8 +78,8 @@ func PackageRecords(urls []string, records warc.Records) (*memfs.Memdir, error) 
 	}
 
 	pkg.AddChildren(
-		memfs.NewMemfileBytes("index.html", indexBuf.Bytes()),
-		memfs.NewMemfileBytes("archive.warc", buf.Bytes()),
+		cafs.NewMemfileBytes("index.html", indexBuf.Bytes()),
+		cafs.NewMemfileBytes("archive.warc", buf.Bytes()),
 	)
 
 	return pkg, nil


### PR DESCRIPTION
memfs has been merged up into its parent pkg github.com/qri-io/cafs.

@b5 Could you have a look please? cheers